### PR TITLE
fixbug: issue of being unusable due to incorrect parameter type.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -57,5 +57,5 @@ export class FingerprinterPlugin {
 }
 
 export function generateFingerprint(options: fingerprintGeneratorOptions | null): FingerprinterPlugin
-export function createFingerprinterInterface(options: fingerprintGeneratorOptions): FingerprinterPlugin
+export function createFingerprinterInterface(options: FingerprintInterface): FingerprinterPlugin
 export declare const commonFingerprint: Fingerprint


### PR DESCRIPTION
Hello JijaProGamer , I'm Eva, I'm very happy to discover the puppeteer-extra-plugin-fingerprinter package, which offers more fingerprinter possibilities.

However, I found out that I can't use the createFingerprinterInterface method because of a type checking problem.

According to the instructions the type declaration should be `function createFingerprinterInterface(options: FingerprintInterface): FingerprinterPlugin`, but I found that the actual type declaration is `function createFingerprinterInterface(options: FingerprintInterface): FingerprinterPlugin`

I tried to change the type description, after the local validation passed, tried to submit a PR , I hope not to interfere with you, if it really meets your scenario, I hope to pass the PR ~

If you have more design logic on your side, I hope you can share with me. 

