### PR TITLE
support cooperative intercepts

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ let staticFingerprint = generateFingerprint({
     canvas: {chance: 95, shift: 4}, // set shift to 0 to cancel canvas spoofing
     proxy: "direct", // Support for string only
     proxy: () => "direct", // Defaults to this, meaning no proxy
-    proxy: () =>  ["direct", "socks5://127.0.0.1"] // Support for array and get a random object
+    proxy: () =>  ["direct", "socks5://127.0.0.1"], // Support for array and get a random object
+    requestInterceptPriorty: 0 // Support for puppeteers cooperative-intercept-mode
 })
 
 // You can save staticFingerprint for later use if you want
@@ -50,6 +51,7 @@ let fingerprinter = createFingerprinterInterface({
         proxy: "direct", // Support for string only
         proxy: () => "direct", // Defaults to this, meaning no proxy
         proxy: () =>  ["direct", "socks5://127.0.0.1"] // Support for array and get a random object
+        requestInterceptPriorty: 0 // Support for puppeteers cooperative-intercept-mode
     },
 
     staticFingerprint: staticFingerprint// Will only use this fingerprint for all pages and browsers if provided,

--- a/index.d.ts
+++ b/index.d.ts
@@ -39,7 +39,8 @@ interface fingerprintGeneratorOptions {
     memory: number | boolReturn | null,
     compatibleMediaMimes: {audio: string[], video: anyString,} | boolReturn | null,
     canvas: {chance: number, shift: number} | boolReturn | null,
-    proxy: string | stringReturn | stringArrayReturn | null
+    proxy: string | stringReturn | stringArrayReturn | null,
+    requestInterceptPriorty: number | null
 }
 
 interface FingerprintInterface {

--- a/index.js
+++ b/index.js
@@ -213,6 +213,7 @@ class FingerprinterPlugin extends PuppeteerExtraPlugin {
         page.options = options
 
         await page.setRequestInterception(true);
+        const INTERCEPT_PRIORITY = this.opts.fingerprint_generator.requestInterceptPriorty || 0
 
         for(let evasion of this.availableEvasions){
             evasionPlugins[evasion](page, page.options)
@@ -259,13 +260,13 @@ class FingerprinterPlugin extends PuppeteerExtraPlugin {
     
                     switch(mode){
                         case "direct":
-                            request.continue({headers})
+                            request.continue({headers}, INTERCEPT_PRIORITY)
                             break
                         case "proxy":
                             useProxy(request, {proxy: page.options.proxy, headers})
                             break
                         case "abort":
-                            request.abort()
+                            request.abort('aborted', INTERCEPT_PRIORITY)
                             break
                     }
                 } catch(err) {
@@ -276,7 +277,7 @@ class FingerprinterPlugin extends PuppeteerExtraPlugin {
                 let proxy = (page.options.proxy || "").trim()
 
                 if(!proxy || proxy == "direct" || proxy == "direct://"){
-                    request.continue({headers})
+                    request.continue({headers}, INTERCEPT_PRIORITY)
                 } else {
                     useProxy(request, {proxy, headers})
                 }


### PR DESCRIPTION
@JijaProGamer hope you don't mind the PR :)

Puppeteer has the ability to set a priority on a request interception so you can define multiple interceptors around the place and have them interact in a nice/well defined way using priorities.

My additions enable these interceptors to play nicely with others that may also be running in other code areas.

Ref:
https://pptr.dev/guides/request-interception#cooperative-intercept-mode